### PR TITLE
Add scripts for image build and e2e test jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,9 @@ else
     BUILD_DATE ?= $(shell date -u "$(DATE_FMT)")
 endif
 
-ifeq ($(shell bash -c '[[ `command -v git` && `git rev-parse --git-dir 2>/dev/null` ]] && echo true'), true)
-	GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || echo unknown)
-	GIT_TREE_STATE := $(if $(shell git status --porcelain --untracked-files=no),dirty,clean)
-	GIT_VERSION := $(shell git describe --abbrev=0 2>/dev/null || echo 0.0.0)
-else
-	GIT_COMMIT := unknown
-	GIT_TREE_STATE := unknown
-	GIT_VERSION := unknown
-endif
+GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || echo unknown)
+GIT_TREE_STATE := $(if $(shell git status --porcelain --untracked-files=no),dirty,clean)
+GIT_VERSION := $(shell git describe --abbrev=0 2>/dev/null || echo 0.0.0)
 
 BUILDTAGS := netgo
 BUILD_FILES := $(shell find . -type f -name '*.go' -or -name '*.mod' -or -name '*.sum' -not -name '*_test.go')

--- a/hack/pull-seccomp-operator-build-image
+++ b/hack/pull-seccomp-operator-build-image
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unset IMAGE
+
+make image

--- a/hack/pull-seccomp-operator-test-e2e
+++ b/hack/pull-seccomp-operator-test-e2e
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+make test-e2e


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We have to ensure kubectl to not have a need to include it into the test
image. This will now be done by the test suite itself to make them more
independent from the environment.
#### Which issue(s) this PR fixes:
Ref https://github.com/kubernetes/test-infra/pull/18301

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
