### PR TITLE
Add cloudbuild.yaml for images in gcr.io

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,19 @@
+---
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/seccomp-operator:$_GIT_TAG
+      - --tag=gcr.io/$PROJECT_ID/seccomp-operator:latest
+      - .
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form
+  # vYYYYMMDD-hash, and can be used as a substitution
+  _GIT_TAG: '12345'
+images:
+  - 'gcr.io/$PROJECT_ID/seccomp-operator:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/seccomp-operator:latest'


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This allows us to utilize Google Cloud Build to build and publish the seccomp-operator images.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
A periodic job in test-infra should later take care in building and publishing the image.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
