### PR TITLE
Watch all namespaces by default

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -3,7 +3,7 @@
 ## Features
 
 - Enables use of `ConfigMap` to store seccomp profiles.
-- Synchronises seccomp profiles across all nodes.
+- Synchronizes seccomp profiles across all nodes.
 
 ## How To
 
@@ -15,14 +15,14 @@ $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/seccomp-ope
 
 ### 2. Create Profile
 
-ConfigMaps with profiles must exist within the `seccomp-operator` namespace and be
+ConfigMaps with profiles will be separated by their target namespace and must be
 annotated with `seccomp.security.kubernetes.io/profile: "true"`. As per below:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: seccomp-operator
+  namespace: my-namespace
   name: cfg-map-name
   annotations:
     seccomp.security.kubernetes.io/profile: "true"
@@ -35,7 +35,7 @@ data:
 
 The operator will get that ConfigMap and save all its profiles into the folder:
 
-`/var/lib/kubelet/seccomp/operator/cfg-map-name/`.
+`/var/lib/kubelet/seccomp/operator/my-namespace/cfg-map-name/`.
 
 ### 3. Apply profile to pod
 
@@ -47,7 +47,7 @@ kind: Pod
 metadata:
   name: test-pod
   annotations:
-    seccomp.security.alpha.kubernetes.io/pod: "localhost/operator/cfg-map-name/profile1.json"
+    seccomp.security.alpha.kubernetes.io/pod: "localhost/operator/my-namespace/cfg-map-name/profile1.json"
 spec:
   containers:
     - name: test-container
@@ -68,13 +68,13 @@ I0618 16:06:55.498089       1 internal.go:393] controller-runtime/manager "msg"=
 I0618 16:06:55.498392       1 controller.go:164] controller-runtime/controller "msg"="Starting EventSource"  "controller"="profile" "source"={"Type":{"metadata":{"creationTimestamp":null}}}
 I0618 16:06:55.598778       1 controller.go:171] controller-runtime/controller "msg"="Starting Controller"  "controller"="profile"
 I0618 16:06:55.598873       1 controller.go:190] controller-runtime/controller "msg"="Starting workers"  "controller"="profile" "worker count"=1
-I0618 16:08:43.507538       1 profile.go:125] profile "msg"="Reconciled profile" "namespace"="seccomp-operator" "profile"="test-profile" "resource version"="2912"
+I0618 16:08:43.507538       1 profile.go:125] profile "msg"="Reconciled profile" "namespace"="my-namespace" "profile"="test-profile" "resource version"="2912"
 ```
 
 Confirm that the seccomp profiles are saved into the correct path:
 
 ```sh
-$ kubectl exec -t -n seccomp-operator seccomp-operator-v6p2h -- ls /var/lib/kubelet/seccomp/operator/test-profile
+$ kubectl exec -t -n seccomp-operator seccomp-operator-v6p2h -- ls /var/lib/kubelet/seccomp/operator/my-namespace/test-profile
 profile-block.json
 profile-complain.json
 ```

--- a/cmd/seccomp-operator/main.go
+++ b/cmd/seccomp-operator/main.go
@@ -30,9 +30,8 @@ import (
 )
 
 const (
-	appName             string = "seccomp-operator"
-	namespaceToWatchKey string = "NAMESPACE_TO_WATCH"
-	jsonFlag            string = "json"
+	appName  string = "seccomp-operator"
+	jsonFlag string = "json"
 )
 
 var (
@@ -98,23 +97,18 @@ func run(*cli.Context) error {
 	)
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
-		return errors.Wrap(err, "cannot get config")
+		return errors.Wrap(err, "get config")
 	}
 
-	opts := ctrl.Options{
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		SyncPeriod: &sync,
-	}
-	if os.Getenv(namespaceToWatchKey) != "" {
-		opts.Namespace = os.Getenv(namespaceToWatchKey)
-	}
-
-	mgr, err := ctrl.NewManager(cfg, opts)
+	})
 	if err != nil {
-		return errors.Wrap(err, "cannot create manager")
+		return errors.Wrap(err, "create manager")
 	}
 
 	if err := profile.Setup(mgr, ctrl.Log.WithName("profile")); err != nil {
-		return errors.Wrap(err, "cannot setup profile controller")
+		return errors.Wrap(err, "setup profile controller")
 	}
 
 	setupLog.Info("starting manager")

--- a/cmd/seccomp-operator/main.go
+++ b/cmd/seccomp-operator/main.go
@@ -30,10 +30,9 @@ import (
 )
 
 const (
-	appName                 string = "seccomp-operator"
-	namespaceToWatchDefault string = appName
-	namespaceToWatchKey     string = "NAMESPACE_TO_WATCH"
-	jsonFlag                string = "json"
+	appName             string = "seccomp-operator"
+	namespaceToWatchKey string = "NAMESPACE_TO_WATCH"
+	jsonFlag            string = "json"
 )
 
 var (
@@ -102,15 +101,14 @@ func run(*cli.Context) error {
 		return errors.Wrap(err, "cannot get config")
 	}
 
-	namespaceToWatch := namespaceToWatchDefault
+	opts := ctrl.Options{
+		SyncPeriod: &sync,
+	}
 	if os.Getenv(namespaceToWatchKey) != "" {
-		namespaceToWatch = os.Getenv(namespaceToWatchKey)
+		opts.Namespace = os.Getenv(namespaceToWatchKey)
 	}
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		SyncPeriod: &sync,
-		Namespace:  namespaceToWatch,
-	})
+	mgr, err := ctrl.NewManager(cfg, opts)
 	if err != nil {
 		return errors.Wrap(err, "cannot create manager")
 	}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: seccomp-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: config-map-reader
   namespace: seccomp-operator
@@ -20,7 +20,7 @@ rules:
   verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: config-map-reader-binding
   namespace: seccomp-operator
@@ -29,7 +29,7 @@ subjects:
   name: seccomp-operator
   namespace: seccomp-operator
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: config-map-reader
   apiGroup: rbac.authorization.k8s.io
 ---
@@ -87,9 +87,6 @@ spec:
         - name: seccomp-operator
           image: securityoperators/seccomp-operator:latest
           imagePullPolicy: Always
-          env:
-          - name: NAMESPACE_TO_WATCH
-            value: seccomp-operator
           volumeMounts:
           - mountPath: /var/lib/kubelet
             name: kubelet-path

--- a/examples/profile.yaml
+++ b/examples/profile.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: seccomp-operator
   name: test-profile
   annotations:
     seccomp.security.kubernetes.io/profile: "true"

--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -42,11 +42,10 @@ const (
 
 	longWait = 1 * time.Minute
 
-	errGetProfile           = "cannot get profile"
-	errConfigMapNil         = "config map cannot be nil"
-	errConfigMapWithoutName = "config map must have a name"
-	errSavingProfile        = "cannot save profile"
-	errCreatingOperatorDir  = "cannot create operator directory"
+	errGetProfile          = "cannot get profile"
+	errConfigMapNil        = "config map cannot be nil"
+	errSavingProfile       = "cannot save profile"
+	errCreatingOperatorDir = "cannot create operator directory"
 
 	seccompOperatorSuffix string      = "seccomp/operator"
 	filePermissionMode    os.FileMode = 0o644
@@ -143,9 +142,6 @@ func saveProfileOnDisk(fileName, contents string) error {
 func getProfilePath(profileName string, cfg *corev1.ConfigMap) (string, error) {
 	if cfg == nil {
 		return "", errors.New(errConfigMapNil)
-	}
-	if cfg.ObjectMeta.Name == "" {
-		return "", errors.New(errConfigMapWithoutName)
 	}
 
 	targetPath := DirTargetPath()

--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -150,6 +150,7 @@ func getProfilePath(profileName string, cfg *corev1.ConfigMap) (string, error) {
 
 	targetPath := DirTargetPath()
 	filePath := path.Join(targetPath,
+		filepath.Base(cfg.ObjectMeta.Namespace),
 		filepath.Base(cfg.ObjectMeta.Name),
 		filepath.Base(profileName))
 

--- a/internal/pkg/controllers/profile/profile_test.go
+++ b/internal/pkg/controllers/profile/profile_test.go
@@ -268,14 +268,6 @@ func TestGetProfilePath(t *testing.T) {
 				},
 			},
 		},
-		"ConfigMapWithoutName": {
-			wantErr: errConfigMapWithoutName,
-			config: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "config-namespace",
-				},
-			},
-		},
 		"ConfigMapCannotBeNil": {
 			wantErr: errConfigMapNil,
 		},

--- a/internal/pkg/controllers/profile/profile_test.go
+++ b/internal/pkg/controllers/profile/profile_test.go
@@ -229,7 +229,7 @@ func TestGetProfilePath(t *testing.T) {
 		config      *corev1.ConfigMap
 	}{
 		"AppendNamespaceConfigNameAndProfile": {
-			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "config-name", "file.js"),
+			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "config-namespace", "config-name", "file.js"),
 			profileName: "file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -239,7 +239,7 @@ func TestGetProfilePath(t *testing.T) {
 			},
 		},
 		"BlockTraversalAtProfileName": {
-			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "cfg", "file.js"),
+			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "ns", "cfg", "file.js"),
 			profileName: "../../../../../file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -249,7 +249,7 @@ func TestGetProfilePath(t *testing.T) {
 			},
 		},
 		"BlockTraversalAtConfigName": {
-			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "cfg", "file.js"),
+			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "ns", "cfg", "file.js"),
 			profileName: "file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -259,7 +259,7 @@ func TestGetProfilePath(t *testing.T) {
 			},
 		},
 		"BlockTraversalAtConfigNamespace": {
-			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "cfg", "file.js"),
+			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "ns", "cfg", "file.js"),
 			profileName: "file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -78,7 +78,7 @@ func (e *e2e) TestSeccompOperator() {
 		for name, content := range defaultProfiles.Data {
 			catOutput := e.run(
 				"docker", "exec", node, "cat",
-				filepath.Join(profile.DirTargetPath(), profile.DefaultProfilesConfigMapName, name),
+				filepath.Join(profile.DirTargetPath(), defaultProfiles.Namespace, profile.DefaultProfilesConfigMapName, name),
 			)
 			e.Contains(catOutput, content)
 		}


### PR DESCRIPTION
#### What type of PR is this?

> /kind feature

#### What this PR does / why we need it:

We decided that the operator should watch every namespace, therefore we can deploy profiles from every namespace.

#### Which issue(s) this PR fixes:

Fixes #40 

#### Special notes for your reviewer:

Different to what we discussed by opted for not pushing the profiles of the "seccomp-operator" namespace in to the top-level directory. They'll end up in a namespace dir just as any other profile. IMO handling the "seccomp-operator" differently would just make the implementation more difficult without adding too much value.

#### Does this PR introduce a user-facing change?

```release-note
seccomp profiles can be created in any namespace now.  Profiles end up in different subdirectories per namespace.
```
