### PR TITLE
Add default profile e2e test case

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -58,10 +58,12 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - >
-              if [ ! -d "/var/lib/kubelet/seccomp/operator" ]; then
-                /bin/mkdir -p /var/lib/kubelet/seccomp/operator &&
-                chmod 0744 /var/lib/kubelet/seccomp/operator &&
-                /bin/chown -R 2000:2000 /var/lib/kubelet/seccomp/operator;
+              KUBELET_DIR=/var/lib/kubelet &&
+              OPERATOR_DIR=$KUBELET_DIR/seccomp/operator &&
+              chmod +x $KUBELET_DIR &&
+              if [ ! -d $OPERATOR_DIR ]; then
+                /bin/mkdir -m 0744 -p $OPERATOR_DIR &&
+                /bin/chown -R 2000:2000 $OPERATOR_DIR;
               fi
           volumeMounts:
           - mountPath: /var/lib/kubelet

--- a/internal/pkg/controllers/profile/profile_test.go
+++ b/internal/pkg/controllers/profile/profile_test.go
@@ -215,7 +215,7 @@ func TestDirTargetPath(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := dirTargetPath()
+			got := DirTargetPath()
 			require.Equal(t, tc.want, got)
 		})
 	}

--- a/profiles/build.go
+++ b/profiles/build.go
@@ -28,11 +28,12 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
+	"github.com/kubernetes-sigs/seccomp-operator/internal/pkg/controllers/profile"
 )
 
 const (
 	deploymentYAML = "deploy/operator.yaml"
-	configMapName  = "default-profiles"
 	profilesDir    = "profiles"
 )
 
@@ -70,7 +71,7 @@ func main() {
 		}
 
 		// look for the right config map
-		if match.foundConfigMapType && line == "  name: "+configMapName {
+		if match.foundConfigMapType && line == "  name: "+profile.DefaultProfilesConfigMapName {
 			match.foundConfigMapName = true
 		}
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -18,11 +18,21 @@ limitations under the License.
 
 package e2e_test
 
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"github.com/kubernetes-sigs/seccomp-operator/internal/pkg/controllers/profile"
+	v1 "k8s.io/api/core/v1"
+)
+
 func (e *e2e) TestSeccompOperator() {
 	const manifest = "deploy/operator.yaml"
 
 	// Ensure that we do not accidentally pull the image and use the pre-loaded
 	// ones from the nodes
+	e.logf("Setting imagePullPolicy to 'Never' in manifest: %s", manifest)
 	e.run(
 		"sed", "-i", "s;imagePullPolicy: Always;imagePullPolicy: Never;g",
 		manifest,
@@ -30,11 +40,47 @@ func (e *e2e) TestSeccompOperator() {
 	defer e.run("git", "checkout", manifest)
 
 	// Deploy the operator
+	e.logf("Deploying operator")
 	e.kubectl("create", "-f", manifest)
 
 	// Wait for the operator to be ready
-	e.kubectl(
-		"-n", "seccomp-operator",
-		"wait", "--for", "condition=ready", "pod", "--all",
+	e.logf("Waiting for operator to be ready")
+	e.kubectlOperatorNS("wait", "--for", "condition=ready", "pod", "--all")
+
+	// Verify that the default profiles are
+	e.logf("Verifying default profiles on all worker nodes")
+	nodes := e.kubectl(
+		"get", "nodes",
+		"-l", "node-role.kubernetes.io/master!=",
+		"-o", `jsonpath={range .items[*]}{@.metadata.name}{" "}{end}`,
 	)
+	e.logf("Got worker nodes: %v", nodes)
+
+	// Get the default profiles
+	e.logf("Retrieving default profiles from configmap: %s", profile.DefaultProfilesConfigMapName)
+	defaultProfilesData := e.kubectlOperatorNS(
+		"get", "configmap", profile.DefaultProfilesConfigMapName, "-o", "json",
+	)
+	var defaultProfiles v1.ConfigMap
+	e.logf("Unmarshalling default profiles JSON: %s", defaultProfilesData)
+	e.Nil(json.Unmarshal([]byte(defaultProfilesData), &defaultProfiles))
+
+	for _, node := range strings.Fields(nodes) {
+		// General path verification
+		e.logf("Verifying seccomp operator directory on node: %s", node)
+		statOutput := e.run(
+			"docker", "exec", node, "stat", "-c", `%a,%u,%g`, profile.DirTargetPath(),
+		)
+		e.Contains(statOutput, "744,2000,2000")
+
+		// Default profile verification
+		e.logf("Verifying default profiles on node: %s", node)
+		for name, content := range defaultProfiles.Data {
+			catOutput := e.run(
+				"docker", "exec", node, "cat",
+				filepath.Join(profile.DirTargetPath(), profile.DefaultProfilesConfigMapName, name),
+			)
+			e.Contains(catOutput, content)
+		}
+	}
 }

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -26,7 +26,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/seccomp-operator/internal/pkg/controllers/profile"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/klog/klogr"
 	"k8s.io/release/pkg/command"
 	"k8s.io/release/pkg/util"
 )
@@ -35,8 +38,7 @@ const (
 	kindVersion = "v0.8.1"
 	kindSHA512  = "ff71adddbe043df84c4dee82f034c6856bfc51c931bb7839d9c09d02fca93bfe961a9c05d7c657371963cc81febee175133598bba50fb1481a9faa06b42abdc3" // nolint: lll
 	kindImage   = "kindest/node:v1.18.2"
-
-	testImage = "securityoperators/seccomp-operator:latest"
+	testImage   = "securityoperators/seccomp-operator:latest"
 )
 
 type e2e struct {
@@ -44,14 +46,16 @@ type e2e struct {
 	kindPath    string
 	kubectlPath string
 	clusterName string
+	logger      logr.Logger
 }
 
 func TestSuite(t *testing.T) {
-	suite.Run(t, &e2e{})
+	suite.Run(t, &e2e{logger: klogr.New()})
 }
 
 // SetupSuite downloads kind and searches for kubectl in $PATH.
 func (e *e2e) SetupSuite() {
+	e.logf("Setting up suite")
 	cwd, err := os.Getwd()
 	e.Nil(err)
 
@@ -61,15 +65,11 @@ func (e *e2e) SetupSuite() {
 	e.Nil(os.MkdirAll(buildDir, 0o755))
 
 	e.kindPath = filepath.Join(buildDir, "kind")
-	if !util.Exists(e.kindPath) {
-		e.run(
-			"curl", "-o", e.kindPath, "-fL",
-			"https://github.com/kubernetes-sigs/kind/releases/download/"+
-				kindVersion+"/kind-linux-amd64",
-		)
-		e.Nil(os.Chmod(e.kindPath, 0o700))
-		e.verifySHA256(e.kindPath, kindSHA512)
-	}
+	e.downloadAndVerify(
+		"https://github.com/kubernetes-sigs/kind/releases/download/"+
+			kindVersion+"/kind-linux-amd64",
+		e.kindPath, kindSHA512,
+	)
 
 	e.kubectlPath, err = exec.LookPath("kubectl")
 	e.Nil(err)
@@ -78,6 +78,7 @@ func (e *e2e) SetupSuite() {
 // SetupTest starts a fresh kind cluster for each test.
 func (e *e2e) SetupTest() {
 	// Deploy the cluster
+	e.logf("Deploying the cluster")
 	e.clusterName = fmt.Sprintf("so-e2e-%d", time.Now().Unix())
 
 	cmd := exec.Command( // nolint: gosec
@@ -92,10 +93,13 @@ func (e *e2e) SetupTest() {
 	e.Nil(cmd.Run())
 
 	// Wait for the nodes to  be ready
+	e.logf("Waiting for cluster to be ready")
 	e.kubectl("wait", "--for", "condition=ready", "nodes", "--all")
 
 	// Build and load the test image
+	e.logf("Building operator container image")
 	e.run("make", "image", "IMAGE="+testImage)
+	e.logf("Loading container image into nodes")
 	e.run(
 		e.kindPath, "load", "docker-image", "--name="+e.clusterName, testImage,
 	)
@@ -103,6 +107,7 @@ func (e *e2e) SetupTest() {
 
 // TearDownTest stops the kind cluster.
 func (e *e2e) TearDownTest() {
+	e.logf("Destroying cluster")
 	e.run(
 		e.kindPath, "delete", "cluster",
 		"--name="+e.clusterName,
@@ -110,17 +115,38 @@ func (e *e2e) TearDownTest() {
 	)
 }
 
-func (e *e2e) run(cmd string, args ...string) {
-	e.Nil(command.Execute(cmd, args...))
+func (e *e2e) run(cmd string, args ...string) string {
+	output, err := command.New(cmd, args...).RunSuccessOutput()
+	e.Nil(err)
+	return output.OutputTrimNL()
 }
 
-func (e *e2e) verifySHA256(binaryPath, sha256 string) {
+func (e *e2e) downloadAndVerify(url, binaryPath, sha512 string) {
+	if !util.Exists(binaryPath) {
+		e.logf("Downloading %s", binaryPath)
+		e.run("curl", "-o", binaryPath, "-fL", url)
+		e.Nil(os.Chmod(binaryPath, 0o700))
+		e.verifySHA512(binaryPath, sha512)
+	}
+}
+
+func (e *e2e) verifySHA512(binaryPath, sha512 string) {
 	e.Nil(command.New("sha512sum", binaryPath).
-		Pipe("grep", sha256).
+		Pipe("grep", sha512).
 		RunSilentSuccess(),
 	)
 }
 
-func (e *e2e) kubectl(args ...string) {
-	e.run(e.kubectlPath, args...)
+func (e *e2e) kubectl(args ...string) string {
+	return e.run(e.kubectlPath, args...)
+}
+
+func (e *e2e) kubectlOperatorNS(args ...string) string {
+	return e.kubectl(
+		append([]string{"-n", profile.DefaultNamespace}, args...)...,
+	)
+}
+
+func (e *e2e) logf(format string, a ...interface{}) {
+	e.logger.Info(fmt.Sprintf(format, a...))
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The e2e tests now verify that the default profile is in place and
contains the right content.

We had to fix an issue where the kubelet path would not be accessible
(`0700`) by the user 2000. This has now being worked around by running
an additional `chmod +x /var/lib/kubelet` on operator boostrap.

Some additional logging has been added to the test framework as well.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Refers to https://github.com/kubernetes-sigs/seccomp-operator/issues/39

#### Special notes for your reviewer:
I opened https://github.com/kubernetes/kubernetes/issues/93652 for discussions on the `/var/lib/kubelet` default permissions in kubeadm.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
