### PR TITLE
Added nginx profile e2e test case

### DIFF
--- a/examples/pod.yaml
+++ b/examples/pod.yaml
@@ -3,8 +3,13 @@ kind: Pod
 metadata:
   name: test-pod
   annotations:
-    seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/test-profile/profile-allow.json'
+    # Use the default nginx profile
+    seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/seccomp-operator/default-profiles/nginx-1.19.1.json'
+    # Or one example within this directory
+    # Please note the syntax:
+    # `localhost/operator/{namespace}/{configmap-name}/{profile-name}`
+    # seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/default/test-profile/profile-allow.json'
 spec:
   containers:
   - name: test-container
-    image: nginx
+    image: nginx:1.19.1

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -97,6 +97,27 @@ func (e *e2e) TestSeccompOperator() {
 		// Example profile verification
 		e.verifyProfilesContent(node, exampleProfiles)
 	}
+
+	// Run the test pod
+	const (
+		examplePodPath = "examples/pod.yaml"
+		examplePodName = "test-pod"
+	)
+	e.logf("Creating the test pod: %s", examplePodPath)
+	e.kubectl("create", "-f", examplePodPath)
+
+	e.logf("Waiting for test pod to be ready")
+	e.kubectl("wait", "--for", "condition=ready", "pod", "--all")
+
+	e.logf("Testing that `rmdir` is not possible inside the pod")
+	failureOutput := e.kubectlFailure(
+		"exec", examplePodName, "--", "rmdir", "/home",
+	)
+	e.Contains(failureOutput,
+		"rmdir: failed to remove '/home': Operation not permitted",
+	)
+
+	e.logf("Tests succeeded")
 }
 
 func (e *e2e) verifyProfilesContent(node string, cm *v1.ConfigMap) {

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -121,6 +121,13 @@ func (e *e2e) run(cmd string, args ...string) string {
 	return output.OutputTrimNL()
 }
 
+func (e *e2e) runFailure(cmd string, args ...string) string {
+	output, err := command.New(cmd, args...).Run()
+	e.Nil(err)
+	e.False(output.Success())
+	return output.Error()
+}
+
 func (e *e2e) downloadAndVerify(url, binaryPath, sha512 string) {
 	if !util.Exists(binaryPath) {
 		e.logf("Downloading %s", binaryPath)
@@ -139,6 +146,10 @@ func (e *e2e) verifySHA512(binaryPath, sha512 string) {
 
 func (e *e2e) kubectl(args ...string) string {
 	return e.run(e.kubectlPath, args...)
+}
+
+func (e *e2e) kubectlFailure(args ...string) string {
+	return e.runFailure(e.kubectlPath, args...)
 }
 
 func (e *e2e) kubectlOperatorNS(args ...string) string {


### PR DESCRIPTION

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
We now deploy the test pod which defaults to the default nginx profile.
We verify that the pod is running as well that a syscall like `rmdir` is
not allowed by the profile.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #39 

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
