### PR TITLE
Fix double symlink creation on operator restart

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -65,7 +65,9 @@ spec:
                 /bin/mkdir -m 0744 -p $SECCOMP_DIR
               fi;
               /bin/chmod 0744 $OPERATOR_DIR &&
-              /bin/ln -s -f $OPERATOR_DIR $OPERATOR_SYMLINK &&             
+              if [ ! -L $OPERATOR_SYMLINK ]; then
+                /bin/ln -s $OPERATOR_DIR $OPERATOR_SYMLINK
+              fi;
               /bin/chown -R 2000:2000 $OPERATOR_DIR
           volumeMounts:
           - name: host-varlib-vol


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If we do not check the symlink before creating it we might be end-up
creating another symlink inside of the already linked directory.

The issue can be reproduced by deploying the operator and removing one
of the pods. Before this patch the init would fail.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
