### PR TITLE
Update pull request template to match latest prow capabilities

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,18 +9,21 @@ https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-k
 
 #### What type of PR is this?
 
-> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
->
-> /kind api-change
-> /kind bug
-> /kind cleanup
-> /kind deprecation
-> /kind design
-> /kind documentation
-> /kind failing-test
-> /kind feature
-> /kind flake
-> /kind regression
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
 
 #### What this PR does / why we need it:
 
@@ -29,9 +32,13 @@ https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-k
 <!--
 *Automatically closes linked issue when PR is merged.
 Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
--->
 
 Fixes #
+
+or
+
+None
+-->
 
 #### Special notes for your reviewer:
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Prow is now able to strip HTML comments for `kind/*` labels, which means
that we can sync-up with the official k/k pull request template.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Refers to https://github.com/kubernetes/kubernetes/pull/89946
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
