### PR TITLE
Initialize the operator with a dedicated subcommand

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -55,23 +55,9 @@ spec:
       serviceAccountName: seccomp-operator
       initContainers:
         - name: non-root-enabler
-          image: busybox
-          # Creates folder /var/lib/seccomp-operator, sets 2000:2000 as its owner and symlink it to /var/lib/kubelet/seccomp/operator.
-          # This is required to allow the main container to run as non-root.
-          command: ["/bin/sh", "-c"]
-          args:
-            - >
-              SECCOMP_DIR=/var/lib/kubelet/seccomp &&
-              OPERATOR_SYMLINK=$SECCOMP_DIR/operator &&
-              OPERATOR_DIR=/var/lib/seccomp-operator &&
-              if [ ! -d $SECCOMP_DIR ]; then
-                /bin/mkdir -m 0744 -p $SECCOMP_DIR
-              fi;
-              /bin/chmod 0744 $OPERATOR_DIR &&
-              if [ ! -L $OPERATOR_SYMLINK ]; then
-                /bin/ln -s $OPERATOR_DIR $OPERATOR_SYMLINK
-              fi;
-              /bin/chown -R 2000:2000 $OPERATOR_DIR
+          image: gcr.io/k8s-staging-seccomp-operator/seccomp-operator:latest
+          imagePullPolicy: Always
+          args: ["init"]
           volumeMounts:
           - name: host-varlib-vol
             mountPath: /var/lib

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+const (
+	// OperatorName is the name when referring to the operator.
+	OperatorName = "seccomp-operator"
+
+	// KubeletSeccompRootPath specifies the path where all kubelet seccomp
+	// profiles are stored.
+	KubeletSeccompRootPath = "/var/lib/kubelet/seccomp"
+
+	// ProfilesRootPath specifies the path where the operator stores seccomp
+	// profiles.
+	ProfilesRootPath = KubeletSeccompRootPath + "/operator"
+
+	// DefaultProfilesConfigMapName is the configMap name for the default
+	// profiles.
+	DefaultProfilesConfigMapName = "default-profiles"
+)

--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"sigs.k8s.io/seccomp-operator/internal/pkg/config"
 	stypes "sigs.k8s.io/seccomp-operator/internal/pkg/types"
 )
 
@@ -57,21 +58,10 @@ const (
 	// https://github.com/golang/go/issues/22323#issuecomment-340568811
 	dirPermissionMode os.FileMode = 0o744
 
-	// ProfileRootPath specifies the path where the operator populates the
-	// profiles.
-	ProfileRootPath = "/var/lib/kubelet/seccomp/operator"
-
-	// DefaultProfilesConfigMapName is the configMap name for the default
-	// profiles.
-	DefaultProfilesConfigMapName = "default-profiles"
-
-	// DefaultNamespace is the default namespace for the operator deployment.
-	DefaultNamespace = "seccomp-operator"
+	// seccompProfileAnnotation is the annotation on a ConfigMap that specifies
+	// its intention to be treated as a seccomp profile.
+	seccompProfileAnnotation = "seccomp.security.kubernetes.io/profile"
 )
-
-// SeccompProfileAnnotation is the annotation on a ConfigMap that specifies its
-// intention to be treated as a seccomp profile.
-const SeccompProfileAnnotation = "seccomp.security.kubernetes.io/profile"
 
 // isProfile checks if a ConfigMap has been designated as a seccomp profile.
 func isProfile(obj runtime.Object) bool {
@@ -80,7 +70,7 @@ func isProfile(obj runtime.Object) bool {
 		return false
 	}
 
-	return r.Annotations[SeccompProfileAnnotation] == "true"
+	return r.Annotations[seccompProfileAnnotation] == "true"
 }
 
 // Setup adds a controller that reconciles seccomp profiles.
@@ -162,7 +152,7 @@ func GetProfilePath(profileName string, cfg *corev1.ConfigMap) (string, error) {
 	}
 
 	return path.Join(
-		ProfileRootPath,
+		config.ProfilesRootPath,
 		filepath.Base(cfg.ObjectMeta.Namespace),
 		filepath.Base(cfg.ObjectMeta.Name),
 		filepath.Base(profileName),

--- a/internal/pkg/controllers/profile/profile_test.go
+++ b/internal/pkg/controllers/profile/profile_test.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/seccomp-operator/internal/pkg/config"
 )
 
 func TestIsProfile(t *testing.T) {
@@ -52,7 +54,7 @@ func TestIsProfile(t *testing.T) {
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						SeccompProfileAnnotation: "true",
+						seccompProfileAnnotation: "true",
 					},
 				},
 			},
@@ -134,7 +136,7 @@ func TestSaveProfileOnDisk(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("Test does not work as root user")
 	}
-	dir, err := ioutil.TempDir("", "seccomp-operator")
+	dir, err := ioutil.TempDir("", config.OperatorName)
 	if err != nil {
 		t.Error(errors.Wrap(err, "error creating temp file for tests"))
 	}
@@ -204,7 +206,7 @@ func TestGetProfilePath(t *testing.T) {
 		config      *corev1.ConfigMap
 	}{
 		"AppendNamespaceConfigNameAndProfile": {
-			want:        path.Join(ProfileRootPath, "config-namespace", "config-name", "file.js"),
+			want:        path.Join(config.ProfilesRootPath, "config-namespace", "config-name", "file.js"),
 			profileName: "file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -214,7 +216,7 @@ func TestGetProfilePath(t *testing.T) {
 			},
 		},
 		"BlockTraversalAtProfileName": {
-			want:        path.Join(ProfileRootPath, "ns", "cfg", "file.js"),
+			want:        path.Join(config.ProfilesRootPath, "ns", "cfg", "file.js"),
 			profileName: "../../../../../file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -224,7 +226,7 @@ func TestGetProfilePath(t *testing.T) {
 			},
 		},
 		"BlockTraversalAtConfigName": {
-			want:        path.Join(ProfileRootPath, "ns", "cfg", "file.js"),
+			want:        path.Join(config.ProfilesRootPath, "ns", "cfg", "file.js"),
 			profileName: "file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -234,7 +236,7 @@ func TestGetProfilePath(t *testing.T) {
 			},
 		},
 		"BlockTraversalAtConfigNamespace": {
-			want:        path.Join(ProfileRootPath, "ns", "cfg", "file.js"),
+			want:        path.Join(config.ProfilesRootPath, "ns", "cfg", "file.js"),
 			profileName: "file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/pkg/initialize/initialize.go
+++ b/internal/pkg/initialize/initialize.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initialize
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"k8s.io/release/pkg/util"
+)
+
+// SetupRootless creates directory in `operatorRootPath`, sets the group and
+// user ID to `guid` and symlinks it to `profilesRootPath`. This is required to
+// allow the main container to run as non-root.
+func SetupRootless(
+	kubeletSeccompRootPath, operatorRootPath, profilesRootPath string,
+	guid int,
+) error {
+	// Create necessary directories
+	const perms = 0o744
+	if !util.Exists(kubeletSeccompRootPath) {
+		if err := os.MkdirAll(kubeletSeccompRootPath, perms); err != nil {
+			return errors.Wrapf(
+				err, "creating seccomp root path: %s", kubeletSeccompRootPath,
+			)
+		}
+	}
+
+	if err := os.MkdirAll(operatorRootPath, perms); err != nil {
+		return errors.Wrapf(
+			err, "creating operator root path: %s", operatorRootPath,
+		)
+	}
+	if err := os.Chmod(operatorRootPath, perms); err != nil {
+		return errors.Wrapf(
+			err, "changing operator root path permissions: %s", operatorRootPath,
+		)
+	}
+
+	// Symlink if necessary
+	if !util.Exists(profilesRootPath) {
+		if err := os.Symlink(operatorRootPath, profilesRootPath); err != nil {
+			return errors.Wrap(
+				err, "linking operator root path into profile root",
+			)
+		}
+	}
+
+	// Change to rootless permissions
+	if err := os.Chown(operatorRootPath, guid, guid); err != nil {
+		return errors.Wrap(err, "changing operator root path permissions")
+	}
+
+	return nil
+}

--- a/internal/pkg/initialize/initialize_test.go
+++ b/internal/pkg/initialize/initialize_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initialize_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/seccomp-operator/internal/pkg/initialize"
+)
+
+func TestSetupRootless(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "so-test-")
+	require.Nil(t, err)
+	defer require.Nil(t, os.RemoveAll(tempDir))
+
+	currentUser, err := user.Current()
+	require.Nil(t, err)
+	uid, err := strconv.Atoi(currentUser.Uid)
+	require.Nil(t, err)
+
+	kubeletSeccompRootPath := filepath.Join(tempDir, "a")
+	operatorRootPath := filepath.Join(tempDir, "b")
+	profilesRootPath := filepath.Join(tempDir, "c")
+
+	for i := 0; i < 2; i++ {
+		require.Nil(t, initialize.SetupRootless(
+			kubeletSeccompRootPath,
+			operatorRootPath,
+			profilesRootPath,
+			uid,
+		))
+	}
+}

--- a/profiles/build.go
+++ b/profiles/build.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"sigs.k8s.io/seccomp-operator/internal/pkg/controllers/profile"
+	"sigs.k8s.io/seccomp-operator/internal/pkg/config"
 )
 
 const (
@@ -71,7 +71,7 @@ func main() {
 		}
 
 		// look for the right config map
-		if match.foundConfigMapType && line == "  name: "+profile.DefaultProfilesConfigMapName {
+		if match.foundConfigMapType && line == "  name: "+config.DefaultProfilesConfigMapName {
 			match.foundConfigMapName = true
 		}
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -26,6 +26,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	"sigs.k8s.io/seccomp-operator/internal/pkg/config"
 	"sigs.k8s.io/seccomp-operator/internal/pkg/controllers/profile"
 )
 
@@ -64,9 +65,9 @@ func (e *e2e) TestSeccompOperator() {
 	e.logf("Got worker nodes: %v", nodes)
 
 	// Get the default profiles
-	e.logf("Retrieving default profiles from configmap: %s", profile.DefaultProfilesConfigMapName)
+	e.logf("Retrieving default profiles from configmap: %s", config.DefaultProfilesConfigMapName)
 	defaultProfilesData := e.kubectlOperatorNS(
-		"get", "configmap", profile.DefaultProfilesConfigMapName, "-o", "json",
+		"get", "configmap", config.DefaultProfilesConfigMapName, "-o", "json",
 	)
 	defaultProfiles := &v1.ConfigMap{}
 	e.logf("Unmarshalling default profiles JSON: %s", defaultProfilesData)
@@ -77,7 +78,7 @@ func (e *e2e) TestSeccompOperator() {
 		// General path verification
 		e.logf("Verifying seccomp operator directory on node: %s", node)
 		statOutput := e.execNode(
-			node, "stat", "-L", "-c", `%a,%u,%g`, profile.ProfileRootPath,
+			node, "stat", "-L", "-c", `%a,%u,%g`, config.ProfilesRootPath,
 		)
 		e.Contains(statOutput, "744,2000,2000")
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -32,14 +32,14 @@ import (
 	"k8s.io/release/pkg/command"
 	"k8s.io/release/pkg/util"
 
-	"sigs.k8s.io/seccomp-operator/internal/pkg/controllers/profile"
+	"sigs.k8s.io/seccomp-operator/internal/pkg/config"
 )
 
 const (
 	kindVersion = "v0.8.1"
 	kindSHA512  = "ff71adddbe043df84c4dee82f034c6856bfc51c931bb7839d9c09d02fca93bfe961a9c05d7c657371963cc81febee175133598bba50fb1481a9faa06b42abdc3" // nolint: lll
 	kindImage   = "kindest/node:v1.18.2"
-	testImage   = "seccomp-operator:latest"
+	testImage   = config.OperatorName + ":latest"
 )
 
 type e2e struct {
@@ -155,7 +155,7 @@ func (e *e2e) kubectlFailure(args ...string) string {
 
 func (e *e2e) kubectlOperatorNS(args ...string) string {
 	return e.kubectl(
-		append([]string{"-n", profile.DefaultNamespace}, args...)...,
+		append([]string{"-n", config.OperatorName}, args...)...,
 	)
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Instead of relying on a bunch of bash code we now write the
initialization phase directly as operator subcommand. This way we can
reuse the already built image and test the code paths.

A new `config` package now contains global consts shared across the
whole application. This way we can decouple it from the `profile`
package.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Reuse operator container image for rootless initialization of the deployment
```
