### PR TITLE
Change from git inferred version to const version value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,9 @@ ADD . /work
 RUN make
 
 FROM scratch
-ARG version
 
 LABEL name="Seccomp Operator" \
-      version=$version \
+      version="0.0.0" \
       description="The Seccomp Operator makes it easier for cluster admins to manage their seccomp profiles and apply them to Kubernetes' workloads."
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ endif
 
 GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || echo unknown)
 GIT_TREE_STATE := $(if $(shell git status --porcelain --untracked-files=no),dirty,clean)
-GIT_VERSION := $(shell git describe --abbrev=0 2>/dev/null || echo 0.0.0)
 
 BUILDTAGS := netgo
 BUILD_FILES := $(shell find . -type f -name '*.go' -or -name '*.mod' -or -name '*.sum' -not -name '*_test.go')
@@ -34,8 +33,7 @@ GO_PROJECT := sigs.k8s.io/$(PROJECT)
 LDVARS := \
 	-X $(GO_PROJECT)/internal/pkg/version.buildDate=$(BUILD_DATE) \
 	-X $(GO_PROJECT)/internal/pkg/version.gitCommit=$(GIT_COMMIT) \
-	-X $(GO_PROJECT)/internal/pkg/version.gitTreeState=$(GIT_TREE_STATE) \
-	-X $(GO_PROJECT)/internal/pkg/version.gitVersion=$(GIT_VERSION)
+	-X $(GO_PROJECT)/internal/pkg/version.gitTreeState=$(GIT_TREE_STATE)
 LDFLAGS := -s -w -linkmode external -extldflags "-static" $(LDVARS)
 
 CONTAINER_RUNTIME ?= docker
@@ -87,7 +85,7 @@ default-profiles: ## Generate the default profiles
 
 .PHONY: image
 image: ## Build the container image
-	$(CONTAINER_RUNTIME) build --build-arg version=$(GIT_VERSION) -t $(IMAGE) .
+	$(CONTAINER_RUNTIME) build -t $(IMAGE) .
 
 # Verification targets
 

--- a/cmd/seccomp-operator/main.go
+++ b/cmd/seccomp-operator/main.go
@@ -47,7 +47,7 @@ func main() {
 	app.Usage = "Kubernetes Seccomp Operator"
 	app.Description = "The Seccomp Operator makes it easier for cluster admins " +
 		"to manage their seccomp profiles and apply them to Kubernetes' workloads."
-	app.Version = version.Get().GitVersion
+	app.Version = version.Get().Version
 	app.Action = run
 	app.Commands = cli.Commands{
 		&cli.Command{
@@ -100,7 +100,7 @@ func run(*cli.Context) error {
 	v := version.Get()
 	setupLog.Info(
 		"starting seccomp-operator",
-		"gitVersion", v.GitVersion,
+		"version", v.Version,
 		"gitCommit", v.GitCommit,
 		"gitTreeState", v.GitTreeState,
 		"buildDate", v.BuildDate,

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -24,15 +24,17 @@ import (
 	"text/tabwriter"
 )
 
+// version is the current version of the operator.
+const version = "0.0.0"
+
 var (
 	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string // state of git tree, either "clean" or "dirty"
-	gitVersion   string // semantic version, derived by build scripts
 )
 
 type Info struct {
-	GitVersion   string `json:"gitVersion,omitempty"`
+	Version      string `json:"version,omitempty"`
 	GitCommit    string `json:"gitCommit,omitempty"`
 	GitTreeState string `json:"gitTreeState,omitempty"`
 	BuildDate    string `json:"buildDate,omitempty"`
@@ -43,7 +45,7 @@ type Info struct {
 
 func Get() *Info {
 	return &Info{
-		GitVersion:   gitVersion,
+		Version:      version,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
 		BuildDate:    buildDate,
@@ -58,7 +60,7 @@ func (i *Info) String() string {
 	b := strings.Builder{}
 	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
 
-	fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
+	fmt.Fprintf(w, "Version:\t%s\n", i.Version)
 	fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
 	fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
 	fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)

--- a/internal/pkg/version/version_test.go
+++ b/internal/pkg/version/version_test.go
@@ -28,7 +28,7 @@ func TestVersionText(t *testing.T) {
 	require.NotEmpty(t, sut.Compiler)
 	require.NotEmpty(t, sut.GitCommit)
 	require.NotEmpty(t, sut.GitTreeState)
-	require.NotEmpty(t, sut.GitVersion)
+	require.NotEmpty(t, sut.Version)
 	require.NotEmpty(t, sut.GoVersion)
 	require.NotEmpty(t, sut.Platform)
 	require.NotEmpty(t, sut.String())


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The git inferred version assumes that the tag exists before bringing the
actual version value into the binary. This breaks our workflow with
respect to pull requests and image promotion, so we stick to a const
value for now.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Refers t

or

None
-->
Refers to #82 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
