### PR TITLE
Stop reconciling on invalid profile

### DIFF
--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -113,7 +113,8 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 			reason := "cannot validate profile " + profileName
 			logger.Error(err, reason)
 			r.record.Event(configMap, event.Warning(event.Reason(reason), err))
-			return reconcile.Result{}, errors.Wrap(err, reason)
+			// do not reconcile again until further change
+			return reconcile.Result{}, nil
 		}
 
 		profilePath, err := GetProfilePath(profileName, configMap)


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If a profile is invalid then we should not reconcile it further until it
has been changed.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
