### PR TITLE
Split-up e2e test into test cases

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -19,105 +19,46 @@ limitations under the License.
 package e2e_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"strings"
-
-	v1 "k8s.io/api/core/v1"
-
-	"sigs.k8s.io/seccomp-operator/internal/pkg/config"
-	"sigs.k8s.io/seccomp-operator/internal/pkg/controllers/profile"
 )
 
-func (e *e2e) TestSeccompOperator() {
-	const manifest = "deploy/operator.yaml"
-	defer e.cleanupOperator(manifest)
-	defer e.run("git", "checkout", manifest)
+const manifest = "deploy/operator.yaml"
 
+func (e *e2e) TestSeccompOperator() {
 	// Deploy the operator
 	e.deployOperator(manifest)
+	defer e.run("git", "checkout", manifest)
 
-	// Deploy the example profile
-	const (
-		exampleProfilePath = "examples/profile.yaml"
-		exampleProfileName = "test-profile"
-	)
-	e.logf("Deploying example profile: %s", exampleProfilePath)
-	e.kubectl("create", "-f", exampleProfilePath)
+	// Retrieve the inputs for the test cases
+	nodes := e.getWorkerNodes()
 
-	e.logf("Retrieving deployed example profile")
-	exampleProfileData := e.kubectl(
-		"get", "configmap", exampleProfileName, "-o", "json",
-	)
-
-	exampleProfiles := &v1.ConfigMap{}
-	e.logf("Unmarshalling example profiles JSON: %s", exampleProfileName)
-	e.Nil(json.Unmarshal([]byte(exampleProfileData), exampleProfiles))
-
-	// Verify that the default profiles are on all worker nodes
-	e.logf("Verifying default profiles on all worker nodes")
-	nodes := e.kubectl(
-		"get", "nodes",
-		"-l", "node-role.kubernetes.io/master!=",
-		"-o", `jsonpath={range .items[*]}{@.metadata.name}{" "}{end}`,
-	)
-	e.logf("Got worker nodes: %v", nodes)
-
-	// Get the default profiles
-	e.logf("Retrieving default profiles from configmap: %s", config.DefaultProfilesConfigMapName)
-	defaultProfilesData := e.kubectlOperatorNS(
-		"get", "configmap", config.DefaultProfilesConfigMapName, "-o", "json",
-	)
-	defaultProfiles := &v1.ConfigMap{}
-	e.logf("Unmarshalling default profiles JSON: %s", defaultProfilesData)
-	e.Nil(json.Unmarshal([]byte(defaultProfilesData), defaultProfiles))
-
-	// Content verification
-	for _, node := range strings.Fields(nodes) {
-		// General path verification
-		e.logf("Verifying seccomp operator directory on node: %s", node)
-		statOutput := e.execNode(
-			node, "stat", "-L", "-c", `%a,%u,%g`, config.ProfilesRootPath,
-		)
-		e.Contains(statOutput, "744,2000,2000")
-
-		// Default profile verification
-		e.verifyProfilesContent(node, defaultProfiles)
-
-		// Example profile verification
-		e.verifyProfilesContent(node, exampleProfiles)
+	// Execute the test cases. Each test case should cleanup on its own and
+	// leave a working operator behind.
+	for _, testCase := range []struct {
+		description string
+		fn          func(nodes []string)
+	}{
+		{
+			"Verify default and example profiles",
+			e.testCaseDefaultAndExampleProfiles,
+		},
+		{
+			"Run a test pod",
+			e.testCaseRunPod,
+		},
+		{
+			"Re-deploy the operator",
+			e.testCaseReDeployOperator,
+		},
+		{
+			"Deploy invalid profile",
+			e.testCaseDeployInvalidProfile,
+		},
+	} {
+		e.logf("> Running testcase: %s", testCase.description)
+		testCase.fn(nodes)
 	}
-
-	// Run the test pod
-	const (
-		examplePodPath = "examples/pod.yaml"
-		examplePodName = "test-pod"
-	)
-	e.logf("Creating the test pod: %s", examplePodPath)
-	e.kubectl("create", "-f", examplePodPath)
-
-	e.logf("Waiting for test pod to be ready")
-	e.kubectl("wait", "--for", "condition=ready", "pod", "--all")
-
-	e.logf("Testing that `rmdir` is not possible inside the pod")
-	failureOutput := e.kubectlFailure(
-		"exec", examplePodName, "--", "rmdir", "/home",
-	)
-	e.Contains(failureOutput,
-		"rmdir: failed to remove '/home': Operation not permitted",
-	)
-
-	e.logf("Cleaning up and re-deploying the operator")
-	// Clean up the operator
-	e.cleanupOperator(manifest)
-
-	// Deploy the operator again
-	e.deployOperator(manifest)
-
-	e.deployInvalidProfile()
-
-	e.logf("Tests succeeded")
 }
 
 func (e *e2e) deployOperator(manifest string) {
@@ -144,50 +85,15 @@ func (e *e2e) deployOperator(manifest string) {
 	e.kubectlOperatorNS("wait", "--for", "condition=ready", "pod", "--all")
 }
 
-func (e *e2e) cleanupOperator(manifest string) {
-	// Clean up the operator
-	e.logf("Cleaning up operator")
-	e.kubectl("delete", "-f", manifest)
-}
+func (e *e2e) getWorkerNodes() []string {
+	e.logf("Getting worker nodes")
+	nodesOutput := e.kubectl(
+		"get", "nodes",
+		"-l", "node-role.kubernetes.io/master!=",
+		"-o", `jsonpath={range .items[*]}{@.metadata.name}{" "}{end}`,
+	)
+	nodes := strings.Fields(nodesOutput)
+	e.logf("Got worker nodes: %v", nodes)
 
-func (e *e2e) verifyProfilesContent(node string, cm *v1.ConfigMap) {
-	e.logf("Verifying %s profile on node %s", cm.Name, node)
-	for name, content := range cm.Data {
-		profilePath, err := profile.GetProfilePath(name, cm)
-		e.Nil(err)
-		catOutput := e.execNode(node, "cat", profilePath)
-		e.Contains(catOutput, content)
-	}
-}
-
-func (e *e2e) deployInvalidProfile() {
-	const invalidProfileContent = `
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: invalid-profile
-  annotations:
-    seccomp.security.kubernetes.io/profile: "true"
-data:
-  profile-invalid.json: |-
-    { "defaultAction": true }
-`
-	e.logf("Deploying an invalid profile")
-	invalidProfile, err := ioutil.TempFile("", "invalid-profile-")
-	e.Nil(err)
-	_, err = invalidProfile.WriteString(invalidProfileContent)
-	e.Nil(err)
-	e.kubectl("create", "-f", invalidProfile.Name())
-
-	// Verify the event
-	eventsOutput := e.kubectl("get", "events")
-	for _, s := range []string{
-		"Warning",
-		"cannot validate profile profile-invalid.json",
-		"configmap/invalid-profile",
-		"decoding seccomp profile: json: cannot unmarshal bool into " +
-			"Go struct field Seccomp.defaultAction of type seccomp.Action",
-	} {
-		e.Contains(eventsOutput, s)
-	}
+	return nodes
 }

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -1,0 +1,81 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/seccomp-operator/internal/pkg/config"
+	"sigs.k8s.io/seccomp-operator/internal/pkg/controllers/profile"
+)
+
+func (e *e2e) testCaseDefaultAndExampleProfiles(nodes []string) {
+	const (
+		exampleProfilePath = "examples/profile.yaml"
+		exampleProfileName = "test-profile"
+	)
+	e.kubectl("create", "-f", exampleProfilePath)
+	defer e.kubectl("delete", "-f", exampleProfilePath)
+
+	e.logf("Retrieving deployed example profile")
+	exampleProfileData := e.kubectl(
+		"get", "configmap", exampleProfileName, "-o", "json",
+	)
+
+	exampleProfiles := &v1.ConfigMap{}
+	e.logf("Unmarshalling example profiles JSON: %s", exampleProfileName)
+	e.Nil(json.Unmarshal([]byte(exampleProfileData), exampleProfiles))
+
+	// Get the default profiles
+	e.logf("Retrieving default profiles from configmap: %s", config.DefaultProfilesConfigMapName)
+	defaultProfilesData := e.kubectlOperatorNS(
+		"get", "configmap", config.DefaultProfilesConfigMapName, "-o", "json",
+	)
+	defaultProfiles := &v1.ConfigMap{}
+	e.logf("Unmarshalling default profiles JSON: %s", defaultProfilesData)
+	e.Nil(json.Unmarshal([]byte(defaultProfilesData), defaultProfiles))
+
+	// Content verification
+	for _, node := range nodes {
+		// General path verification
+		e.logf("Verifying seccomp operator directory on node: %s", node)
+		statOutput := e.execNode(
+			node, "stat", "-L", "-c", `%a,%u,%g`, config.ProfilesRootPath,
+		)
+		e.Contains(statOutput, "744,2000,2000")
+
+		// Default profile verification
+		e.verifyProfilesContent(node, defaultProfiles)
+
+		// Example profile verification
+		e.verifyProfilesContent(node, exampleProfiles)
+	}
+}
+
+func (e *e2e) verifyProfilesContent(node string, cm *v1.ConfigMap) {
+	e.logf("Verifying %s profile on node %s", cm.Name, node)
+	for name, content := range cm.Data {
+		profilePath, err := profile.GetProfilePath(name, cm)
+		e.Nil(err)
+		catOutput := e.execNode(node, "cat", profilePath)
+		e.Contains(catOutput, content)
+	}
+}

--- a/test/tc_invalid_profile_test.go
+++ b/test/tc_invalid_profile_test.go
@@ -1,0 +1,60 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+func (e *e2e) testCaseDeployInvalidProfile([]string) {
+	const invalidProfileContent = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: invalid-profile
+  annotations:
+    seccomp.security.kubernetes.io/profile: "true"
+data:
+  profile-invalid.json: |-
+    { "defaultAction": true }
+`
+	invalidProfile, err := ioutil.TempFile("", "invalid-profile-")
+	e.Nil(err)
+
+	_, err = invalidProfile.WriteString(invalidProfileContent)
+	e.Nil(err)
+	e.kubectl("create", "-f", invalidProfile.Name())
+	defer func() {
+		e.kubectl("delete", "-f", invalidProfile.Name())
+		e.Nil(os.RemoveAll(invalidProfile.Name()))
+	}()
+
+	// Verify the event
+	eventsOutput := e.kubectl("get", "events")
+	for _, s := range []string{
+		"Warning",
+		"cannot validate profile profile-invalid.json",
+		"configmap/invalid-profile",
+		"decoding seccomp profile: json: cannot unmarshal bool into " +
+			"Go struct field Seccomp.defaultAction of type seccomp.Action",
+	} {
+		e.Contains(eventsOutput, s)
+	}
+}

--- a/test/tc_redeploy_operator_test.go
+++ b/test/tc_redeploy_operator_test.go
@@ -1,0 +1,33 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+func (e *e2e) testCaseReDeployOperator([]string) {
+	// Clean up the operator
+	e.cleanupOperator(manifest)
+
+	// Deploy the operator again
+	e.deployOperator(manifest)
+}
+
+func (e *e2e) cleanupOperator(manifest string) {
+	// Clean up the operator
+	e.logf("Cleaning up operator")
+	e.kubectl("delete", "-f", manifest)
+}

--- a/test/tc_run_pod_test.go
+++ b/test/tc_run_pod_test.go
@@ -1,0 +1,41 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+func (e *e2e) testCaseRunPod([]string) {
+	const (
+		examplePodPath = "examples/pod.yaml"
+		examplePodName = "test-pod"
+	)
+
+	e.logf("Creating the test pod: %s", examplePodPath)
+	e.kubectl("create", "-f", examplePodPath)
+	defer e.kubectl("delete", "-f", examplePodPath)
+
+	e.logf("Waiting for test pod to be ready")
+	e.kubectl("wait", "--for", "condition=ready", "pod", "--all")
+
+	e.logf("Testing that `rmdir` is not possible inside the pod")
+	failureOutput := e.kubectlFailure(
+		"exec", examplePodName, "--", "rmdir", "/home",
+	)
+	e.Contains(failureOutput,
+		"rmdir: failed to remove '/home': Operation not permitted",
+	)
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
We now use dedicated functions and files for the test cases to be able
keep the tests clean. Every test case expects a valid working operator
to be deployed and is expected to cleanup on its own.

#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
