### PR TITLE
Verify that invalid profile gets not reconciled on disk

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -19,8 +19,11 @@ limitations under the License.
 package e2e_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 const manifest = "deploy/operator.yaml"
@@ -96,4 +99,13 @@ func (e *e2e) getWorkerNodes() []string {
 	e.logf("Got worker nodes: %v", nodes)
 
 	return nodes
+}
+
+func (e *e2e) getConfigMap(name, namespace string) *v1.ConfigMap {
+	configMapJSON := e.kubectl(
+		"-n", namespace, "get", "configmap", name, "-o", "json",
+	)
+	configMap := &v1.ConfigMap{}
+	e.Nil(json.Unmarshal([]byte(configMapJSON), configMap))
+	return configMap
 }

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package e2e_test
 
 import (
-	"encoding/json"
-
 	v1 "k8s.io/api/core/v1"
 
 	"sigs.k8s.io/seccomp-operator/internal/pkg/config"
@@ -36,22 +34,13 @@ func (e *e2e) testCaseDefaultAndExampleProfiles(nodes []string) {
 	defer e.kubectl("delete", "-f", exampleProfilePath)
 
 	e.logf("Retrieving deployed example profile")
-	exampleProfileData := e.kubectl(
-		"get", "configmap", exampleProfileName, "-o", "json",
-	)
-
-	exampleProfiles := &v1.ConfigMap{}
-	e.logf("Unmarshalling example profiles JSON: %s", exampleProfileName)
-	e.Nil(json.Unmarshal([]byte(exampleProfileData), exampleProfiles))
+	exampleProfiles := e.getConfigMap(exampleProfileName, "default")
 
 	// Get the default profiles
 	e.logf("Retrieving default profiles from configmap: %s", config.DefaultProfilesConfigMapName)
-	defaultProfilesData := e.kubectlOperatorNS(
-		"get", "configmap", config.DefaultProfilesConfigMapName, "-o", "json",
+	defaultProfiles := e.getConfigMap(
+		config.DefaultProfilesConfigMapName, config.OperatorName,
 	)
-	defaultProfiles := &v1.ConfigMap{}
-	e.logf("Unmarshalling default profiles JSON: %s", defaultProfilesData)
-	e.Nil(json.Unmarshal([]byte(defaultProfilesData), defaultProfiles))
 
 	// Content verification
 	for _, node := range nodes {


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We now additionally verify that the invalid profile does not exist on
the node in the corresponding e2e test.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
None
-->
None

#### Special notes for your reviewer:
As a follow-up I'd like to re-patch the configmap to be valid again and then check if it gets reconciled to disk.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
