### PR TITLE
Add new security context to example pod

### DIFF
--- a/examples/pod.yaml
+++ b/examples/pod.yaml
@@ -12,4 +12,9 @@ metadata:
 spec:
   containers:
   - name: test-container
+    # Use the seccomp field for Kubernetes versions > v1.19.0
+    # securityContext:
+      # seccompProfile:
+        # type: Localhost
+        # localhostProfile: operator/seccomp-operator/default-profiles/nginx-1.19.1.json
     image: nginx:1.19.1


### PR DESCRIPTION

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
Mention in the example pod that we can use the v1.19.0 securityContext
seccomp profile field.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added new `seccompProfile` field to `examples/pod.yaml`, which can be used for Kubernetes releases > v1.19.0
```
