### PR TITLE
Update k/release to 0.4.0 and make e2e test commands verbose

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/klog/v2 v2.3.0
-	k8s.io/release v0.3.4
+	k8s.io/release v0.4.0
 	sigs.k8s.io/controller-runtime v0.6.2
 )

--- a/go.sum
+++ b/go.sum
@@ -878,6 +878,8 @@ k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C
 k8s.io/release v0.3.2-0.20200513161026-05b87eb96960/go.mod h1:fcMNfhJFSHSBFv4BSrzJV2mesdz3yJeEqsqKs8cxjGU=
 k8s.io/release v0.3.4 h1:2xJMXe10GRiyA4hSFCUmUhw94frGJ2u7pt6VKoXu9XI=
 k8s.io/release v0.3.4/go.mod h1:1F0YT93mvq2mNUFk2tw4mCdHMhWzOlzZ8Z78WfqOg2s=
+k8s.io/release v0.4.0 h1:jNPnFbG8zbw5Pyux3yO2CXDuAMprJDAVmX6WltQL5Dw=
+k8s.io/release v0.4.0/go.mod h1:tO06ZHe7wrnqALxHzVJ1fV2lli4V7CeURZcqRmtrPCk=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTUt3aVoBpi2DqRsU=

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -57,6 +57,7 @@ func TestSuite(t *testing.T) {
 // SetupSuite downloads kind and searches for kubectl in $PATH.
 func (e *e2e) SetupSuite() {
 	e.logf("Setting up suite")
+	command.SetGlobalVerbose(true)
 	cwd, err := os.Getwd()
 	e.Nil(err)
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The latest version of k/release allows us to set commands into global
verbosity mode, which makes running the e2e tests more verbose.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
