### PR TITLE
Re-enable restricting controller watch to single namespace

### DIFF
--- a/cmd/seccomp-operator/main.go
+++ b/cmd/seccomp-operator/main.go
@@ -30,7 +30,10 @@ import (
 	"sigs.k8s.io/seccomp-operator/internal/pkg/version"
 )
 
-const jsonFlag string = "json"
+const (
+	jsonFlag      string = "json"
+	restrictNSKey string = "RESTRICT_TO_NAMESPACE"
+)
 
 var (
 	sync     = time.Second * 30
@@ -98,9 +101,15 @@ func run(*cli.Context) error {
 		return errors.Wrap(err, "get config")
 	}
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+	ctrlOpts := ctrl.Options{
 		SyncPeriod: &sync,
-	})
+	}
+
+	if os.Getenv(restrictNSKey) != "" {
+		ctrlOpts.Namespace = os.Getenv(restrictNSKey)
+	}
+
+	mgr, err := ctrl.NewManager(cfg, ctrlOpts)
 	if err != nil {
 		return errors.Wrap(err, "create manager")
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Adds the ability to restrict the seccomp controller to a single
namespace such that users can restrict permissions required to run the
operator in a cluster.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Part of #63 

#### Special notes for your reviewer:

This was previously removed, but is needed if we want to be able to restrict the RBAC permissions required to only be at the namespace scope, per #63.

I will follow this up with guidance on tighter RBAC, as well as e2e tests.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds ability to restrict seccomp-operator to watch config maps in a single namespace
```
