### PR TITLE
Add support for deployment into master nodes

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -134,6 +134,12 @@ spec:
         hostPath:
           path: /var/lib/seccomp-operator
           type: DirectoryOrCreate
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Allows for seccomp operator to work in master nodes. This is achieved by adding a master node toleration.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This won't impact managed clusters (AKS, GKE, EKS) that does not have master nodes as part of the node pool.

#### Does this PR introduce a user-facing change?

```release-note
Add support for seccomp operator in master nodes
```

/cc @hasheddan @saschagrunert 
