### PR TITLE
Define nodeselector for linux os

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -140,6 +140,8 @@ spec:
         - effect: NoExecute
           key: node.kubernetes.io/not-ready
           operator: Exists
+      nodeSelector:
+        kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Explicitly defines a `nodeSelector` to ensure the operator is deployed in linux nodes. 

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is handy for mixed OS cluster deployments, specially when users are not using OS taints.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
