### PR TITLE
Add deployment manifest for watching single namespace

### DIFF
--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1,0 +1,249 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: seccomp-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: seccomp-operator
+  namespace: seccomp-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: config-map-reader
+  namespace: NS_REPLACE
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: config-map-reader-binding
+  namespace: NS_REPLACE
+subjects:
+- kind: ServiceAccount
+  name: seccomp-operator
+  namespace: seccomp-operator
+roleRef:
+  kind: Role
+  name: config-map-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seccomp-operator-profile
+  namespace: seccomp-operator
+data:
+  seccomp-operator.json: |-
+    {
+      "defaultAction": "SCMP_ACT_ERRNO",
+      "architectures": [
+          "SCMP_ARCH_X86_64",
+          "SCMP_ARCH_X86",
+          "SCMP_ARCH_X32"
+      ],
+      "syscalls": [
+          {
+              "names": [
+                "accept4",
+                "arch_prctl",
+                "bind",
+                "brk",
+                "clone",
+                "close",
+                "connect",
+                "epoll_create1",
+                "epoll_ctl",
+                "epoll_pwait",
+                "execve",
+                "exit",
+                "exit_group",
+                "fcntl",
+                "fstat",
+                "futex",
+                "getcwd",
+                "getgid",
+                "getpeername",
+                "getpgrp",
+                "getpid",
+                "getppid",
+                "getrandom",
+                "getsockname",
+                "getsockopt",
+                "gettid",
+                "getuid",
+                "listen",
+                "madvise",
+                "membarrier",
+                "mkdirat",
+                "mlock",
+                "mmap",
+                "mprotect",
+                "nanosleep",
+                "newfstatat",
+                "open",
+                "openat",
+                "pipe2",
+                "pread64",
+                "read",
+                "readlinkat",
+                "rt_sigaction",
+                "rt_sigprocmask",
+                "rt_sigreturn",
+                "sched_getaffinity",
+                "sched_yield",
+                "setgid",
+                "setsockopt",
+                "set_tid_address",
+                "setuid",
+                "sigaltstack",
+                "socket",
+                "tgkill",
+                "uname",
+                "write"
+              ],
+              "action": "SCMP_ACT_ALLOW"
+          }
+      ]
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: seccomp-operator
+  namespace: seccomp-operator
+spec:
+  selector:
+    matchLabels:
+      name: seccomp-operator
+  template:
+    metadata:
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        container.seccomp.security.alpha.kubernetes.io/seccomp-operator: localhost/seccomp-operator.json
+      labels:
+        name: seccomp-operator
+    spec:
+      serviceAccountName: seccomp-operator
+      initContainers:
+        - name: non-root-enabler
+          image: bash:5.0
+          # Creates folder /var/lib/seccomp-operator, sets 2000:2000 as its
+          # owner and symlink it to /var/lib/kubelet/seccomp/operator. This is
+          # required to allow the main container to run as non-root.
+          command: [bash, -c]
+          args:
+            - |+
+              set -euo pipefail
+
+              if [ ! -d $KUBELET_SECCOMP_ROOT ]; then
+                /bin/mkdir -m 0744 -p $KUBELET_SECCOMP_ROOT
+              fi
+
+              /bin/mkdir -p $OPERATOR_ROOT
+              /bin/chmod 0744 $OPERATOR_ROOT
+
+              if [ ! -L $OPERATOR_SYMLINK ]; then
+                /bin/ln -s $OPERATOR_ROOT $OPERATOR_SYMLINK
+              fi
+
+              /bin/chown -R 2000:2000 $OPERATOR_ROOT
+              cp -f -v /opt/seccomp-profiles/* $KUBELET_SECCOMP_ROOT
+          env:
+            - name: KUBELET_SECCOMP_ROOT
+              value: /var/lib/kubelet/seccomp
+            - name: OPERATOR_SYMLINK
+              value: $(KUBELET_SECCOMP_ROOT)/operator
+            - name: OPERATOR_ROOT
+              value: /var/lib/seccomp-operator
+          volumeMounts:
+            - name: host-varlib-volume
+              mountPath: /var/lib
+            - name: profile-configmap-volume
+              mountPath: /opt/seccomp-profiles
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN", "FOWNER", "FSETID", "DAC_OVERRIDE"]
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "100m"
+              ephemeral-storage: "10Mi"
+            limits:
+              memory: "64Mi"
+              cpu: "250m"
+              ephemeral-storage: "50Mi"
+      containers:
+        - name: seccomp-operator
+          image: gcr.io/k8s-staging-seccomp-operator/seccomp-operator:latest
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: host-operator-volume
+            mountPath: /var/lib/kubelet/seccomp/operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+              ephemeral-storage: "50Mi"
+            limits:
+              memory: "128Mi"
+              cpu: "300m"
+              ephemeral-storage: "200Mi"
+          env:
+            - name: RESTRICT_TO_NAMESPACE
+              value: NS_REPLACE
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      volumes:
+      # /var/lib is used as symlinks cannot be created across different volumes
+      - name: host-varlib-volume
+        hostPath:
+          path: /var/lib
+          type: Directory
+      - name: host-operator-volume
+        hostPath:
+          path: /var/lib/seccomp-operator
+          type: DirectoryOrCreate
+      - name: profile-configmap-volume
+        configMap:
+          name: seccomp-operator-profile
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: NS_REPLACE
+  name: default-profiles
+  annotations:
+    seccomp.security.kubernetes.io/profile: "true"
+data:
+  nginx-1.19.1.json: |-
+    {"defaultAction":"SCMP_ACT_ERRNO","architectures":["SCMP_ARCH_X86_64","SCMP_ARCH_X86","SCMP_ARCH_X32"],"syscalls":[{"names":["accept4","access","arch_prctl","bind","brk","capget","capset","chdir","chown","clone","close","connect","dup2","epoll_create","epoll_ctl","epoll_pwait","epoll_wait","eventfd2","execve","exit","exit_group","faccessat","fadvise64","fchdir","fchown","fcntl","fgetxattr","fsetxattr","fstat","fstatfs","futex","getcwd","getdents","getdents64","getegid","geteuid","getgid","getpid","getppid","getrlimit","getuid","ioctl","io_setup","listen","lseek","mkdir","mmap","mprotect","munmap","nanosleep","newfstatat","open","openat","pipe","prctl","pread64","prlimit64","pwrite64","read","recvfrom","recvmsg","rename","rt_sigaction","rt_sigprocmask","rt_sigreturn","rt_sigsuspend","sched_getaffinity","seccomp","sendfile","sendmsg","setgid","setgroups","setitimer","set_robust_list","setsockopt","set_tid_address","setuid","sigaltstack","socket","socketpair","stat","statfs","sysinfo","umask","uname","unlink","utimensat","wait4","write","writev"],"action":"SCMP_ACT_ALLOW","args":[],"comment":"","includes":{},"excludes":{}}]}

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -62,6 +62,20 @@ spec:
       image: nginx
 ```
 
+## Restricting to a Single Namespace
+
+The seccomp-operator can optionally be run to watch ConfigMaps in a single
+namespace. This is advantageous because it allows for tightening the RBAC
+permissions required by the operator's ServiceAccount. To modify the operator
+deployment to run in a single namespace, use the `namespace-operator.yaml`
+manifest with your namespace of choice:
+
+```sh
+NAMESPACE=<your-namespace>
+
+curl https://raw.githubusercontent.com/kubernetes-sigs/seccomp-operator/master/deploy/namespace-operator.yaml | sed "s/NS_REPLACE/$NAMESPACE/g" | kubectl apply -f -
+```
+
 ## Troubleshooting
 
 Confirm that the profile is being reconciled:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Adds deployment manifest and usage instructions for running the operator watching for profile ConfigMaps in a single namespace.

#### Which issue(s) this PR fixes:


Fixes #63 


#### Special notes for your reviewer:

Will follow this up with an e2e test. Added a release not even though a previous PR technically enabled this functionality.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added manifest for deploying operator to watch for profile ConfigMaps in a single namespace.
```
