### PR TITLE
Update eventing and reconcile logic

### DIFF
--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -144,13 +144,14 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 
 		if err = saveProfileOnDisk(profilePath, profileContent); err != nil {
 			logger.Error(err, "reason", "cannot save profile into disk")
-			r.record.Event(configMap, event.Warning(event.Reason("cannot save profile into disk"), err))
+			r.record.Event(configMap, event.Warning(event.Reason("cannot save profile to disk"), err))
 			return reconcile.Result{RequeueAfter: wait}, nil
 		}
 	}
 
 	logger.Info("Reconciled profile", "resource version", configMap.GetResourceVersion())
-	return reconcile.Result{RequeueAfter: wait}, nil
+	r.record.Event(configMap, event.Normal(event.Reason("save profile to disk"), "Successfully saved profile to disk."))
+	return reconcile.Result{}, nil
 }
 
 func saveProfileOnDisk(fileName, contents string) error {

--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -125,7 +125,9 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 			os.Getenv(config.NodeNameEnvKey),
 		)
 		logger.Error(err, "reason", reason)
-		r.record.Event(configMap, event.Warning(reasonSeccompNotSupported, err, os.Getenv(config.NodeNameEnvKey), "node does not support seccomp"))
+		r.record.Event(configMap,
+			event.Warning(reasonSeccompNotSupported, err, os.Getenv(config.NodeNameEnvKey),
+				"node does not support seccomp"))
 
 		// Do not requeue (will be requeued if a change to the object is
 		// observed, or after the usually very long reconcile timeout

--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -47,7 +47,7 @@ const (
 	// default reconcile timeout.
 	reconcileTimeout = 1 * time.Minute
 
-	wait = 1 * time.Minute
+	wait = 30 * time.Second
 
 	errGetProfile          = "cannot get profile"
 	errConfigMapNil        = "config map cannot be nil"

--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -47,7 +47,7 @@ const (
 	// default reconcile timeout.
 	reconcileTimeout = 1 * time.Minute
 
-	longWait = 1 * time.Minute
+	wait = 1 * time.Minute
 
 	errGetProfile          = "cannot get profile"
 	errConfigMapNil        = "config map cannot be nil"
@@ -139,18 +139,18 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		if err != nil {
 			logger.Error(err, "reason", "cannot get profile path")
 			r.record.Event(configMap, event.Warning(event.Reason("cannot get profile path"), err))
-			return reconcile.Result{}, err
+			return reconcile.Result{RequeueAfter: wait}, nil
 		}
 
 		if err = saveProfileOnDisk(profilePath, profileContent); err != nil {
 			logger.Error(err, "reason", "cannot save profile into disk")
 			r.record.Event(configMap, event.Warning(event.Reason("cannot save profile into disk"), err))
-			return reconcile.Result{}, err
+			return reconcile.Result{RequeueAfter: wait}, nil
 		}
 	}
 
 	logger.Info("Reconciled profile", "resource version", configMap.GetResourceVersion())
-	return reconcile.Result{RequeueAfter: longWait}, nil
+	return reconcile.Result{RequeueAfter: wait}, nil
 }
 
 func saveProfileOnDisk(fileName, contents string) error {

--- a/internal/pkg/controllers/profile/profile_test.go
+++ b/internal/pkg/controllers/profile/profile_test.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -108,13 +109,20 @@ func TestReconcile(t *testing.T) {
 			rec: &Reconciler{
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(nil, func(obj runtime.Object) error {
+						obj = &corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      name,
+								Namespace: namespace,
+							},
+						}
 						return nil
 					}),
 				},
-				log: log.Log,
+				log:    log.Log,
+				record: event.NewNopRecorder(),
 			},
 			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
-			wantResult: reconcile.Result{RequeueAfter: wait},
+			wantResult: reconcile.Result{},
 			wantErr:    nil,
 		},
 	}

--- a/internal/pkg/controllers/profile/profile_test.go
+++ b/internal/pkg/controllers/profile/profile_test.go
@@ -114,7 +114,7 @@ func TestReconcile(t *testing.T) {
 				log: log.Log,
 			},
 			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
-			wantResult: reconcile.Result{RequeueAfter: longWait},
+			wantResult: reconcile.Result{RequeueAfter: wait},
 			wantErr:    nil,
 		},
 	}

--- a/internal/pkg/controllers/profile/profile_test.go
+++ b/internal/pkg/controllers/profile/profile_test.go
@@ -108,15 +108,7 @@ func TestReconcile(t *testing.T) {
 		"GotProfile": {
 			rec: &Reconciler{
 				client: &test.MockClient{
-					MockGet: test.NewMockGetFn(nil, func(obj runtime.Object) error {
-						obj = &corev1.ConfigMap{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      name,
-								Namespace: namespace,
-							},
-						}
-						return nil
-					}),
+					MockGet: test.NewMockGetFn(nil),
 				},
 				log:    log.Log,
 				record: event.NewNopRecorder(),

--- a/test/tc_invalid_profile_test.go
+++ b/test/tc_invalid_profile_test.go
@@ -64,7 +64,7 @@ data:
 	eventsOutput := e.kubectl("get", "events")
 	for _, s := range []string{
 		"Warning",
-		"cannot validate profile " + profileName,
+		"InvalidSeccompProfile",
 		"configmap/" + configMapName,
 		"decoding seccomp profile: json: cannot unmarshal bool into " +
 			"Go struct field Seccomp.defaultAction of type seccomp.Action",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updates eventing style to be more aligned with Kubernetes style. Also avoids constant reconciles when there is an error writing a profile to disk.

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

Also reduced `wait` to 30 seconds now that we are only using it in error cases.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Do not requeue after successfully writing profile to disk and do not immediately requeue on errors.
```
