### PR TITLE
Remove leading `v` from image version

### DIFF
--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -187,7 +187,7 @@ spec:
               ephemeral-storage: "50Mi"
       containers:
         - name: seccomp-operator
-          image: k8s.gcr.io/seccomp-operator/seccomp-operator:v0.1.0
+          image: k8s.gcr.io/seccomp-operator/seccomp-operator:0.1.0
           imagePullPolicy: Always
           volumeMounts:
           - name: host-operator-volume

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -187,7 +187,7 @@ spec:
               ephemeral-storage: "50Mi"
       containers:
         - name: seccomp-operator
-          image: k8s.gcr.io/seccomp-operator/seccomp-operator:v0.1.0
+          image: k8s.gcr.io/seccomp-operator/seccomp-operator:0.1.0
           imagePullPolicy: Always
           volumeMounts:
           - name: host-operator-volume


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We should not add leading `v`s to container images.
#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
