### PR TITLE
Validate profile by building the seccomp filter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,9 @@
 ---
 run:
   build-tags:
-    - netgo
     - e2e
+    - netgo
+    - seccomp
   concurrency: 6
   deadline: 5m
 linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM golang:1.15-alpine AS build
 WORKDIR /work
-RUN apk --no-cache add build-base git gcc
+RUN apk --no-cache add build-base git gcc libseccomp-dev
 
 ENV USER=secuser
 ENV UID=2000

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || echo unknown)
 GIT_TREE_STATE := $(if $(shell git status --porcelain --untracked-files=no),dirty,clean)
 VERSION := $(shell cat VERSION)
 
-BUILDTAGS := netgo
+BUILDTAGS := netgo seccomp
 BUILD_FILES := $(shell find . -type f -name '*.go' -or -name '*.mod' -or -name '*.sum' -not -name '*_test.go')
 GO_PROJECT := sigs.k8s.io/$(PROJECT)
 LDVARS := \
@@ -129,9 +129,9 @@ $(BUILD_DIR)/golangci-lint:
 
 .PHONY: test-unit
 test-unit: $(BUILD_DIR) ## Run the unit tests
-	$(GO) test -ldflags '$(LDVARS)' -v -test.coverprofile=$(BUILD_DIR)/coverage.out ./...
+	$(GO) test -ldflags '$(LDVARS)' -tags '$(BUILDTAGS)' -v -test.coverprofile=$(BUILD_DIR)/coverage.out ./...
 	$(GO) tool cover -html $(BUILD_DIR)/coverage.out -o $(BUILD_DIR)/coverage.html
 
 .PHONY: test-e2e
 test-e2e: ## Run the end-to-end tests
-	$(GO) test -timeout 20m -tags e2e -count=1 ./test/... -v
+	$(GO) test -timeout 20m -tags 'e2e $(BUILDTAGS)' -count=1 ./test/... -v

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/seccomp-operator
 go 1.15
 
 require (
-	github.com/containers/common v0.20.3-0.20200827091701-a550d6a98aa3 // can be built with the `seccomp` build tag to support more features
+	github.com/containers/common v0.21.0
 	github.com/crossplane/crossplane-runtime v0.9.0
 	github.com/go-logr/logr v0.2.1
 	github.com/pkg/errors v0.9.1
@@ -15,3 +15,5 @@ require (
 	k8s.io/release v0.4.0
 	sigs.k8s.io/controller-runtime v0.6.2
 )
+
+replace github.com/containers/common => github.com/saschagrunert/common v0.20.3-0.20200908080721-143cdae3b077

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,7 @@ github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv
 github.com/containers/ocicrypt v1.0.2/go.mod h1:nsOhbP19flrX6rE7ieGFvBlr7modwmNjsqWarIUce4M=
 github.com/containers/storage v1.20.2/go.mod h1:oOB9Ie8OVPojvoaKWEGSEtHbXUAs+tSyr7RO7ZGteMc=
 github.com/containers/storage v1.23.2/go.mod h1:AyTMMiE5ANvZJiqvatQgSZ85wAl5yHucY3NDN/kemr4=
+github.com/containers/storage v1.23.4/go.mod h1:KzpVgmUucelPYHq2YsseUTiTuucdVh3xfpPNmxmPZRU=
 github.com/coreos/bbolt v1.3.1-coreos.6/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -374,6 +375,7 @@ github.com/klauspost/compress v1.10.11/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdY
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
+github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -539,6 +541,8 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.0.2/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
 github.com/saschagrunert/ccli v1.0.2-0.20200423111659-b68f755cc0f5/go.mod h1:nF6F8YjOZIYqRQ2GVOi43O13vaN2W1OQq1LcxUGdAfw=
+github.com/saschagrunert/common v0.20.3-0.20200908080721-143cdae3b077 h1:AWDV7Zhebd6Jc1LKy0qatAJp1nrqwgEFHhs49aZjCvw=
+github.com/saschagrunert/common v0.20.3-0.20200908080721-143cdae3b077/go.mod h1:bLba5IGhwoT3ZoD8LRGjp6Jimnyk7qXvnwroY364j2Y=
 github.com/saschagrunert/go-modiff v1.2.0/go.mod h1:YHrztU7folCi4YSHksLOYTX5KFGdHNr9O9DVKjpINMs=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=

--- a/hack/pull-seccomp-operator-build
+++ b/hack/pull-seccomp-operator-build
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# assume a Debian based golang image, like: golang:1.15
+apt-get update
+apt-get install -y libseccomp-dev
+
 make

--- a/hack/pull-seccomp-operator-test-e2e
+++ b/hack/pull-seccomp-operator-test-e2e
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# assume a Debian based golang image, like: golang:1.15
+apt-get update
+apt-get install -y libseccomp-dev
+
 make test-e2e

--- a/hack/pull-seccomp-operator-test-unit
+++ b/hack/pull-seccomp-operator-test-unit
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# assume a Debian based golang image, like: golang:1.15
+apt-get update
+apt-get install -y libseccomp-dev
+
 make test-unit

--- a/hack/pull-seccomp-operator-verify
+++ b/hack/pull-seccomp-operator-verify
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # assume a Debian based golang image, like: golang:1.15
 apt-get update
-apt-get install -y python3
+apt-get install -y python3 libseccomp-dev
 
 # install kustomize
 pushd /usr/bin

--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -18,7 +18,6 @@ package profile
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -131,7 +130,7 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 	}
 
 	for profileName, profileContent := range configMap.Data {
-		if err := validateProfile(profileContent); err != nil {
+		if err := seccomp.ValidateProfile(profileContent); err != nil {
 			logger.Error(err, "cannot validate profile "+profileName)
 			r.record.Event(configMap,
 				event.Warning(reasonInvalidSeccompProfile, err,
@@ -211,16 +210,4 @@ func ignoreNotFound(err error) error {
 		return nil
 	}
 	return err
-}
-
-// validateProfile does a basic validation for the provided seccomp profile
-// string.
-func validateProfile(content string) error {
-	profile := &seccomp.Seccomp{}
-	if err := json.Unmarshal([]byte(content), &profile); err != nil {
-		return errors.Wrap(err, "decoding seccomp profile")
-	}
-
-	// TODO: consider further validation steps
-	return nil
 }

--- a/internal/pkg/controllers/profile/profile_test.go
+++ b/internal/pkg/controllers/profile/profile_test.go
@@ -289,25 +289,3 @@ func TestIgnoreNotFound(t *testing.T) {
 		})
 	}
 }
-
-func TestValidateProfile(t *testing.T) {
-	for _, tc := range []struct {
-		profile       string
-		shouldSucceed bool
-	}{
-		{"wrong", false},
-		{`{"defaultAction": true}`, false},
-		{`{"syscalls": "wrong"}`, false},
-		{`{}`, true},
-		{`{"defaultAction": "SCMP_ACT_ALLOW"}`, true},
-		{`{"syscalls": []}`, true},
-	} {
-		msg := "Profile content: " + tc.profile
-		err := validateProfile(tc.profile)
-		if tc.shouldSucceed {
-			require.Nil(t, err, msg)
-		} else {
-			require.NotNil(t, err, msg)
-		}
-	}
-}


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The new `containers/common` `ValidateProfile()` API can be used to build
a libseccomp filter without loading it into the kernel. This can be now
used by the operator to have a more in-depth profile validation. This
now requires the `seccomp` build tag and a (statically) compiled version
of libseccomp.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes #119 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Changed profile validation to build the whole filter without loading it into the kernel
```
