### PR TITLE
Continue if a profile is invalid

### DIFF
--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -139,8 +139,10 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 			reason := "cannot validate profile " + profileName
 			logger.Error(err, "reason", reason)
 			r.record.Event(configMap, event.Warning(reasonInvalidSeccompProfile, err))
-			// do not reconcile again until further change
-			return reconcile.Result{}, nil
+
+			// it might be possible that other profiles in the configMap are
+			// valid
+			continue
 		}
 
 		profilePath, err := GetProfilePath(profileName, configMap)


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
It might be possible that the configmap contains more valid profiles.
This means we can continue but still throw the warning event.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Fixed bug to reconcile all profiles in a configMap if one of them is invalid.
```
